### PR TITLE
Fix /metrics method and library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/Jyllands-Posten/play-prometheus-filters-example-app
 To use the library add the following to you build.sbt:
 
 ```scala
-libraryDependencies += "io.github.stijndehaes" %% "play-prometheus-filters" % "0.6.0"
+libraryDependencies += "io.github.jyllands-posten" %% "play-prometheus-filters" % "0.6.1"
 
 ```
 This latest version supports Play 2.8.
@@ -165,7 +165,7 @@ play-prometheus-filters {
 The project also provides a prometheus controller with a get metric method. If you add the following to your routes file:
 
 ```
-GET         /metrics          io.github.stijndehaes.playprometheusfilters.controllers.PrometheusController.getMetrics
+GET         /metrics          com.github.stijndehaes.playprometheusfilters.controllers.PrometheusController.getMetrics
 ```
 
 You should be able to immediately get the metrics


### PR DESCRIPTION
The library dependency specified in README.md was incorrect, I took the right version from example project.
`/metrics` method name in routes in README.md was also incorrect which caused compilation error for me. Fixed that too