### PR TITLE
Updating to Play3 & Pekko

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,21 @@
+version = "3.4.3"
+runner.dialect = scala213
+maxColumn = 120
+align.preset = none
+align.multiline = false
+continuationIndent.defnSite = 2
+assumeStandardLibraryStripMargin = true
+docstrings.style = Asterisk
+lineEndings = preserve
+includeCurlyBraceInSelectChains = false
+danglingParentheses.preset = true
+optIn.annotationNewlines = true
+newlines.alwaysBeforeMultilineDef = false
+
+rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.generalExpressions = false
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For more info on play version compatibility see the releases matrix.
 
 | Release | Play version |
 |:--------|:-------------|
-| TBC     | 3.0.x        |
+| 1.0.0   | 3.0.x        |
 | 0.6.x   | 2.8.x        |
 
 For earlier play versions, see the original repository [play-prometheus-filters](https://github.com/stijndehaes/play-prometheus-filters)

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ To use the library add the following to you build.sbt:
 libraryDependencies += "io.github.jyllands-posten" %% "play-prometheus-filters" % "0.6.1"
 
 ```
-This latest version supports Play 2.8.
+This latest version supports Play 3.0.
 For more info on play version compatibility see the releases matrix.
 
 
 ## Releases
 
-| Release     | Play version |
-| :---------- | :----------- |
-| 0.6.x       | 2.8.x        |
+| Release | Play version |
+|:--------|:-------------|
+| TBC     | 3.0.x        |
+| 0.6.x   | 2.8.x        |
 
 For earlier play versions, see the original repository [play-prometheus-filters](https://github.com/stijndehaes/play-prometheus-filters)
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "io.github.jyllands-posten"
 
 version := "0.6.2-SNAPSHOT"
 
-lazy val root = (project in file("."))
+lazy val root = project in file(".")
 
 // All publishing configuration resides in sonatype.sbt
 publishTo := sonatypePublishToBundle.value
@@ -14,8 +14,8 @@ credentials += Credentials(Path.userHome / ".sbt" / ".credentials.sonatype")
 scalaVersion := "2.13.8"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.15")
 
-val playVersion = "2.8.13"
-val prometheusClientVersion = "0.9.0"
+val playVersion = "3.0.0"
+val prometheusClientVersion = "0.16.0"
 
 libraryDependencies ++= Seq(
   "io.prometheus" % "simpleclient" % prometheusClientVersion,
@@ -23,15 +23,15 @@ libraryDependencies ++= Seq(
   "io.prometheus" % "simpleclient_servlet" % prometheusClientVersion,
 
   // Play libs. Are provided not to enforce a specific version.
-  "com.typesafe.play" %% "play" % playVersion % Provided,
-  "com.typesafe.play" %% "play-guice" % playVersion % Provided,
+  "org.playframework" %% "play" % playVersion % Provided,
+  "org.playframework" %% "play-guice" % playVersion % Provided,
 
   // This library makes some Scala 2.13 APIs available on Scala 2.11 and 2.12.
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0"
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1"
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.0" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
-  "org.mockito" % "mockito-core" % "4.2.0" % Test
+  "org.mockito" % "mockito-core" % "5.8.0" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 name := "play-prometheus-filters"
 organization := "io.github.jyllands-posten"
 
-version := "0.6.2-SNAPSHOT"
+version := "1.0.0"
 
 lazy val root = project in file(".")
 

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusController.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusController.scala
@@ -1,6 +1,6 @@
 package com.github.stijndehaes.playprometheusfilters.controllers
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.github.stijndehaes.playprometheusfilters.utils.WriterAdapter
 import javax.inject._
 import play.api.mvc._

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilter.scala
@@ -1,22 +1,24 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyOnlyRequestMetricsBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyOnlyRequestMetricsBuilder
+import com.github.stijndehaes.playprometheusfilters.metrics.{DefaultPlayUnmatchedDefaults, LatencyRequestMetric}
 import io.prometheus.client.CollectorRegistry
-import javax.inject.{Inject, Singleton}
+import org.apache.pekko.actor.ActorSystem
 import play.api.Configuration
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
+import org.apache.pekko.stream.Materializer
 
 /**
   * A simple [[MetricsFilter]] using a histogram metric to record latency without any labels.
   */
 @Singleton
-class LatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit mat: Materializer, ec: ExecutionContext) extends MetricsFilter(configuration) {
+class LatencyFilter @Inject()(registry: CollectorRegistry, configuration: Configuration)(implicit val actorSystem: ActorSystem, ec: ExecutionContext) extends MetricsFilter(configuration) {
 
-  override val metrics = List(
+  override implicit val mat: Materializer = Materializer(actorSystem)
+
+  override val metrics: List[LatencyRequestMetric] = List(
     LatencyOnlyRequestMetricsBuilder.build(registry, DefaultPlayUnmatchedDefaults)
   )
 }

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/MetricsFilter.scala
@@ -1,12 +1,13 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.{CounterRequestMetrics, LatencyRequestMetrics, RequestMetric, RequestMetricBuilder}
 import io.prometheus.client.Collector
+import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 /**
   * Generic filter implementation to add metrics for a request.
@@ -37,7 +38,6 @@ abstract class MetricsFilter(configuration: Configuration)(implicit val mat: Mat
   val metrics: List[RequestMetric[_, RequestHeader, Result]]
 
   val excludePaths = {
-    import collection.JavaConverters._
     Option(configuration.underlying)
       .map(_.getStringList("play-prometheus-filters.exclude.paths"))
       .map(_.asScala.toSet)

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilter.scala
@@ -1,13 +1,12 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.RouteLatencyRequestMetricsBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.RouteLatencyRequestMetricsBuilder
 import io.prometheus.client.CollectorRegistry
-import javax.inject.{Inject, Singleton}
+import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilter.scala
@@ -1,13 +1,12 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
-import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
 import io.prometheus.client.CollectorRegistry
-import javax.inject.{Inject, Singleton}
+import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilter.scala
@@ -1,15 +1,13 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
 import io.prometheus.client._
-import javax.inject.{Inject, Singleton}
+import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilter.scala
@@ -1,13 +1,12 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.LatencyRequestMetrics.LatencyRequestMetricsBuilder
 import io.prometheus.client.CollectorRegistry
-import javax.inject.{Inject, Singleton}
+import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilter.scala
@@ -1,13 +1,12 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import akka.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.StatusCounterRequestMetricBuilder
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
-import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.StatusCounterRequestMetricBuilder
 import io.prometheus.client.CollectorRegistry
-import javax.inject.{Inject, Singleton}
+import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusControllerSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusControllerSpec.scala
@@ -1,8 +1,5 @@
 package com.github.stijndehaes.playprometheusfilters.controllers
 
-import java.util.Collections
-
-import com.github.stijndehaes.playprometheusfilters.controllers.PrometheusController
 import io.prometheus.client.Collector.MetricFamilySamples
 import io.prometheus.client.{Collector, CollectorRegistry}
 import org.mockito.Mockito._
@@ -11,6 +8,8 @@ import org.scalatestplus.play.PlaySpec
 import play.api.mvc.Results
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+
+import java.util.Collections
 
 
 class PrometheusControllerSpec extends PlaySpec with Results with MockitoSugar {
@@ -30,5 +29,4 @@ class PrometheusControllerSpec extends PlaySpec with Results with MockitoSugar {
       contentAsString(result) mustBe "# HELP test help\n# TYPE test counter\n"
     }
   }
-
 }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusControllerSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/controllers/PrometheusControllerSpec.scala
@@ -26,7 +26,7 @@ class PrometheusControllerSpec extends PlaySpec with Results with MockitoSugar {
 
       val result = client.getMetrics.apply(request)
       status(result) mustBe OK
-      contentAsString(result) mustBe "# HELP test help\n# TYPE test counter\n"
+      contentAsString(result) mustBe "# HELP test_total help\n# TYPE test_total counter\n"
     }
   }
 }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
@@ -1,8 +1,9 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.filters.LatencyFilter
+import org.apache.pekko.stream.Materializer
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.actor.ActorSystem
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
@@ -17,11 +18,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class LatencyFilterSpec extends PlaySpec with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
 
-  val configuration = mock[Configuration]
+  private implicit val actorSystem: ActorSystem = ActorSystem("test")
+
+  private val configuration: Configuration = mock[Configuration]
 
   "Filter constructor" should {
     "Add a histogram to the prometheus registry" in {
-      implicit val mat = app.materializer
       val collectorRegistry = mock[CollectorRegistry]
       new LatencyFilter(collectorRegistry, configuration)
       verify(collectorRegistry).register(any())
@@ -30,7 +32,7 @@ class LatencyFilterSpec extends PlaySpec with MockitoSugar with Results with Def
 
   "Apply method" should {
     "Measure the latency" in {
-      implicit val mat = app.materializer
+      implicit val mat: Materializer = app.materializer
       val filter = new LatencyFilter(mock[CollectorRegistry], configuration)
       val rh = FakeRequest()
       val action = new MockController(stubControllerComponents()).ok

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/LatencyFilterSpec.scala
@@ -51,12 +51,14 @@ class LatencyFilterSpec
 
       val maybeRequestLatencySecondsCount: Option[MetricSample] =
         toMetricSamples(metrics.head.samples)
-          .find(_.metricName == "requests_latency_seconds_count")
+          .find(_.metricName.equals("requests_latency_seconds_count"))
 
       metrics must have size 1
       maybeRequestLatencySecondsCount must not be empty
-      maybeRequestLatencySecondsCount.get.value mustBe 1.0
-      maybeRequestLatencySecondsCount.get.labels must have size 0
+      maybeRequestLatencySecondsCount.map { result =>
+        result.value mustBe 1.0
+        result.labelValues must have size 0
+      }
     }
   }
 }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/MetricFilterSpec.scala
@@ -1,14 +1,17 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
 import com.github.stijndehaes.playprometheusfilters.metrics.CounterRequestMetrics.CounterRequestMetricBuilder
-import com.github.stijndehaes.playprometheusfilters.metrics.{DefaultPlayUnmatchedDefaults, RequestMetric}
+import com.github.stijndehaes.playprometheusfilters.metrics.{CounterRequestMetric, DefaultPlayUnmatchedDefaults, RequestMetric}
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import com.typesafe.config.ConfigFactory
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
+import scala.jdk.CollectionConverters._
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
@@ -17,13 +20,15 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
 
-  val configuration = Configuration(ConfigFactory.parseString(
+  implicit val actorSystem: ActorSystem = ActorSystem("test")
+
+  val configuration: Configuration = Configuration(ConfigFactory.parseString(
     """play-prometheus-filters.exclude.paths = ["/test"]"""
   ))
 
   "Filter constructor" should {
     "Get exclude paths from configuration" in {
-      implicit val mat = app.materializer
+      implicit val mat: Materializer = app.materializer
       val filter = new MetricsFilter(configuration) {
         override val metrics = List.empty[RequestMetric[_, RequestHeader, Result]]
       }
@@ -34,10 +39,10 @@ class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with Defa
 
   "Apply method" should {
     "skip metrics for excluded paths" in {
-      implicit val mat = app.materializer
+      implicit val mat: Materializer = app.materializer
       val collectorRegistry = mock[CollectorRegistry]
       val filter = new MetricsFilter(configuration) {
-        override val metrics = List(
+        override val metrics: List[CounterRequestMetric] = List(
           CounterRequestMetricBuilder.build(collectorRegistry, DefaultPlayUnmatchedDefaults)
         )
       }
@@ -47,9 +52,9 @@ class MetricFilterSpec extends PlaySpec with MockitoSugar with Results with Defa
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.metrics(0).metric.collect()
+      val metrics = filter.metrics.head.metric.collect().asScala
       metrics must have size 1
-      val samples = metrics.get(0).samples
+      val samples = metrics.head.samples
       samples.size() mustBe 0 // expect no metrics
     }
   }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
@@ -3,6 +3,8 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.scalatest.matchers.must.Matchers
@@ -20,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class RouteLatencyFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
@@ -3,6 +3,8 @@ package com.github.stijndehaes.playprometheusfilters.filters
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.scalatest.matchers.must.Matchers
@@ -20,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class StatusAndRouteCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
@@ -1,12 +1,12 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.filters.StatusAndRouteLatencyAndCounterFilter
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.times
+import org.mockito.Mockito.{times, verify}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class StatusAndRouteLatencyAndCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
@@ -1,9 +1,9 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.helpers.Conversions._
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults._
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
-import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify}
@@ -20,7 +20,14 @@ import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class StatusAndRouteLatencyAndCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
+class StatusAndRouteLatencyAndCounterFilterSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with Results
+    with DefaultAwaitTimeout
+    with FutureAwaits
+    with GuiceOneAppPerSuite {
 
   private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
@@ -36,36 +43,39 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends AnyWordSpec with Matcher
   "Apply method" should {
     "Measure the latency and count" in {
       val filter = new StatusAndRouteLatencyAndCounterFilter(mock[CollectorRegistry], configuration)
-      val rh = FakeRequest().withAttrs( TypedMap(
-        Router.Attrs.HandlerDef -> HandlerDef(null, null, "testController", "test", null, "GET", "/path", null ,null)
-      ))
+      val rh = FakeRequest().withAttrs(
+        TypedMap(
+          Router.Attrs.HandlerDef -> HandlerDef(null, null, "testController", "test", null, "GET", "/path", null, null)
+        )
+      )
       val action = new MockController(stubControllerComponents()).ok
 
       await(filter(action)(rh).run())
 
-      val latencyMetrics = filter.metrics(0).metric.collect()
+      val latencyMetrics = filter.metrics.head.metric.collect()
       latencyMetrics must have size 1
-      val latencySamples = latencyMetrics.get(0).samples
-      val latencySample = latencySamples.get(latencySamples.size() - 2)
-      latencySample.value mustBe 1.0
-      latencySample.labelValues must have size 5
-      latencySample.labelValues.get(0) mustBe "test"
-      latencySample.labelValues.get(1) mustBe "200"
-      latencySample.labelValues.get(2) mustBe "testController"
-      latencySample.labelValues.get(3) mustBe "/path"
-      latencySample.labelValues.get(4) mustBe "GET"
 
-      val countMetrics = filter.metrics(1).metric.collect()
-      countMetrics must have size 1
-      val countSamples = countMetrics.get(0).samples
-      val countSample = countSamples.get(0)
-      countSample.value mustBe 1.0
-      countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe "test"
-      countSample.labelValues.get(1) mustBe "200"
-      countSample.labelValues.get(2) mustBe "testController"
-      countSample.labelValues.get(3) mustBe "/path"
-      countSample.labelValues.get(4) mustBe "GET"
+      val maybeRequestLatencySecondsCount: Option[MetricSample] =
+        toMetricSamples(latencyMetrics.head.samples)
+          .find(_.metricName.equals("requests_latency_seconds_count"))
+
+      maybeRequestLatencySecondsCount must not be empty
+      maybeRequestLatencySecondsCount.map { result =>
+        result.value mustBe 1.0
+        result.labelValues must have size 5
+        result.labelValues mustBe List("test", "200", "testController", "/path", "GET")
+      }
+
+      val maybeRequestLatencySecondsBucket: Option[MetricSample] =
+        toMetricSamples(latencyMetrics.head.samples)
+          .find(_.metricName.equals("requests_latency_seconds_bucket"))
+
+      maybeRequestLatencySecondsBucket must not be empty
+      maybeRequestLatencySecondsBucket.map { result =>
+        result.value mustBe 0.0
+        result.labelValues must have size 6
+        result.labelValues mustBe List("test", "200", "testController", "/path", "GET", "0.005")
+      }
     }
 
     "Measure the latency and count for an unmatched route" in {
@@ -75,30 +85,43 @@ class StatusAndRouteLatencyAndCounterFilterSpec extends AnyWordSpec with Matcher
 
       await(filter(action)(rh).run())
 
-      val latencyMetrics = filter.metrics(0).metric.collect()
+      val latencyMetrics = filter.metrics.head.metric.collect()
       latencyMetrics must have size 1
-      val latencySamples = latencyMetrics.get(0).samples
-      val latencySample = latencySamples.get(latencySamples.size() - 2)
 
-      latencySample.value mustBe 1.0
-      latencySample.labelValues must have size 5
-      latencySample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
-      latencySample.labelValues.get(1) mustBe "404"
-      latencySample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
-      latencySample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
-      latencySample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
+      val maybeRequestLatencySecondsCount: Option[MetricSample] =
+        toMetricSamples(latencyMetrics.head.samples)
+          .find(_.metricName.equals("requests_latency_seconds_count"))
 
-      val countMetrics = filter.metrics(1).metric.collect()
-      countMetrics must have size 1
-      val countSamples = countMetrics.get(0).samples
-      val countSample = countSamples.get(0)
-      countSample.value mustBe 1.0
-      countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
-      countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
-      countSample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
-      countSample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
+      maybeRequestLatencySecondsCount must not be empty
+      maybeRequestLatencySecondsCount.map { result =>
+        result.value mustBe 1.0
+        result.labelValues must have size 5
+        result.labelValues mustBe List(
+          UnmatchedRouteString,
+          "404",
+          UnmatchedControllerString,
+          UnmatchedPathString,
+          UnmatchedVerbString
+        )
+      }
+
+      val maybeRequestLatencySecondsBucket: Option[MetricSample] =
+        toMetricSamples(latencyMetrics.head.samples)
+          .find(_.metricName.equals("requests_latency_seconds_bucket"))
+
+      maybeRequestLatencySecondsBucket must not be empty
+      maybeRequestLatencySecondsBucket.map { result =>
+        result.value mustBe 1.0
+        result.labelValues must have size 6
+        result.labelValues mustBe List(
+          UnmatchedRouteString,
+          "404",
+          UnmatchedControllerString,
+          UnmatchedPathString,
+          UnmatchedVerbString,
+          "0.005"
+        )
+      }
     }
   }
 }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -1,9 +1,10 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.filters.StatusAndRouteLatencyFilter
 import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.scalatest.matchers.must.Matchers
@@ -21,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class StatusAndRouteLatencyFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -1,9 +1,9 @@
 package com.github.stijndehaes.playprometheusfilters.filters
 
-import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults
+import com.github.stijndehaes.playprometheusfilters.helpers.Conversions._
+import com.github.stijndehaes.playprometheusfilters.metrics.DefaultPlayUnmatchedDefaults._
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
-import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
@@ -20,7 +20,14 @@ import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class StatusAndRouteLatencyFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
+class StatusAndRouteLatencyFilterSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with Results
+    with DefaultAwaitTimeout
+    with FutureAwaits
+    with GuiceOneAppPerSuite {
 
   private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
@@ -36,25 +43,28 @@ class StatusAndRouteLatencyFilterSpec extends AnyWordSpec with Matchers with Moc
   "Apply method" should {
     "Measure the latency" in {
       val filter = new StatusAndRouteLatencyFilter(mock[CollectorRegistry], configuration)
-      val rh = FakeRequest().withAttrs( TypedMap(
-        Router.Attrs.HandlerDef -> HandlerDef(null, null, "testController", "test", null, "GET", "/path", null ,null)
-      ))
+      val rh = FakeRequest().withAttrs(
+        TypedMap(
+          Router.Attrs.HandlerDef -> HandlerDef(null, null, "testController", "test", null, "GET", "/path", null, null)
+        )
+      )
       val action = new MockController(stubControllerComponents()).ok
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.metrics(0).metric.collect()
-      metrics must have size 1
-      val samples = metrics.get(0).samples
-      //this is the count sample
-      val countSample = samples.get(samples.size() - 2)
-      countSample.value mustBe 1.0
-      countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe "test"
-      countSample.labelValues.get(1) mustBe "200"
-      countSample.labelValues.get(2) mustBe "testController"
-      countSample.labelValues.get(3) mustBe "/path"
-      countSample.labelValues.get(4) mustBe "GET"
+      val latencyMetrics = filter.metrics.head.metric.collect()
+      latencyMetrics must have size 1
+
+      val maybeRequestLatencySecondsCount: Option[MetricSample] =
+        toMetricSamples(latencyMetrics.head.samples)
+          .find(_.metricName.equals("requests_latency_seconds_count"))
+
+      maybeRequestLatencySecondsCount must not be empty
+      maybeRequestLatencySecondsCount.map { result =>
+        result.value mustBe 1.0
+        result.labelValues must have size 5
+        result.labelValues mustBe List("test", "200", "testController", "/path", "GET")
+      }
     }
 
     "Measure the latency for an unmatched route" in {
@@ -64,18 +74,25 @@ class StatusAndRouteLatencyFilterSpec extends AnyWordSpec with Matchers with Moc
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.metrics(0).metric.collect()
-      metrics must have size 1
-      val samples = metrics.get(0).samples
-      //this is the count sample
-      val countSample = samples.get(samples.size() - 2)
-      countSample.value mustBe 1.0
-      countSample.labelValues must have size 5
-      countSample.labelValues.get(0) mustBe DefaultPlayUnmatchedDefaults.UnmatchedRouteString
-      countSample.labelValues.get(1) mustBe "404"
-      countSample.labelValues.get(2) mustBe DefaultPlayUnmatchedDefaults.UnmatchedControllerString
-      countSample.labelValues.get(3) mustBe DefaultPlayUnmatchedDefaults.UnmatchedPathString
-      countSample.labelValues.get(4) mustBe DefaultPlayUnmatchedDefaults.UnmatchedVerbString
+      val latencyMetrics = filter.metrics.head.metric.collect()
+      latencyMetrics must have size 1
+
+      val maybeRequestLatencySecondsCount: Option[MetricSample] =
+        toMetricSamples(latencyMetrics.head.samples)
+          .find(_.metricName.equals("requests_latency_seconds_count"))
+
+      maybeRequestLatencySecondsCount must not be empty
+      maybeRequestLatencySecondsCount.map { result =>
+        result.value mustBe 1.0
+        result.labelValues must have size 5
+        result.labelValues mustBe List(
+          UnmatchedRouteString,
+          "404",
+          UnmatchedControllerString,
+          UnmatchedPathString,
+          UnmatchedVerbString
+        )
+      }
     }
   }
 }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
@@ -2,6 +2,7 @@ package com.github.stijndehaes.playprometheusfilters.filters
 
 import com.github.stijndehaes.playprometheusfilters.mocks.MockController
 import io.prometheus.client.CollectorRegistry
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.scalatest.matchers.must.Matchers
@@ -17,7 +18,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class StatusCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {
@@ -36,7 +37,7 @@ class StatusCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSuga
 
       await(filter(action)(rh).run())
 
-      val metrics = filter.metrics(0).metric.collect()
+      val metrics = filter.metrics.head.metric.collect()
       metrics must have size 1
       val samples = metrics.get(0).samples
       samples.get(0).value mustBe 1.0

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/helpers/Conversions.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/helpers/Conversions.scala
@@ -7,7 +7,7 @@ import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 object Conversions {
 
-  case class MetricSample(metricName: String, value: Double, labels: List[String])
+  case class MetricSample(metricName: String, value: Double, labelValues: List[String])
 
   def toMetricSamples(javaMetricSamples: util.List[MetricFamilySamples.Sample]): List[MetricSample] = javaMetricSamples.map { sample =>
     MetricSample(sample.name, sample.value, sample.labelValues)

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/helpers/Conversions.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/helpers/Conversions.scala
@@ -1,0 +1,17 @@
+package com.github.stijndehaes.playprometheusfilters.helpers
+
+import io.prometheus.client.Collector.MetricFamilySamples
+
+import java.util
+import scala.jdk.CollectionConverters._
+import scala.language.implicitConversions
+object Conversions {
+
+  case class MetricSample(metricName: String, value: Double, labels: List[String])
+
+  def toMetricSamples(javaMetricSamples: util.List[MetricFamilySamples.Sample]): List[MetricSample] = javaMetricSamples.map { sample =>
+    MetricSample(sample.name, sample.value, sample.labelValues)
+  }
+
+  implicit def toScalaList[A](jList: java.util.List[A]): List[A] = jList.asScala.toList
+}


### PR DESCRIPTION
Hi @Jyllands-Posten, please could you review this PR?

- Upgraded from Play2 to Play3.
- Replaced Akka dependencies with their Pekko equivalents.
- Added implicit conversions from Java to Scala lists in unit tests to make the code more readable and less brittle.
- Updated unit tests with some safer, more readable, less brittle references to particular metric samples (e.g. `requests_latency_seconds_count` as opposed to `x.get(x.size - 2)`).
  - Also added a case class to organise the samples in tests and allow them to be clearly filtered by sample name as mentioned above.
- Updated "help" test  to include the `_total` suffix according to [Prometheus naming conventions](https://prometheus.io/docs/practices/naming/).
- Incremented major version (to 1.0.0) to signify breaking change (not backwards compatible with Play2).