### PR TITLE
Update Play and other Scala libraries, resolve minor warnings and drop Scala 2.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@ target
 /.project
 /.settings
 /RUNNING_PID
-/.bloop
+.bloop/
+.metals/
+.bsp
+.vscode
+metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,9 @@ lazy val root = (project in file("."))
 publishTo := sonatypePublishToBundle.value
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials.sonatype")
 
-scalaVersion := "2.13.8"
-crossScalaVersions := Seq(scalaVersion.value, "2.12.15")
+scalaVersion := "2.13.12"
 
-val playVersion = "2.8.13"
+val playVersion = "2.9.0"
 val prometheusClientVersion = "0.9.0"
 
 libraryDependencies ++= Seq(
@@ -27,11 +26,11 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-guice" % playVersion % Provided,
 
   // This library makes some Scala 2.13 APIs available on Scala 2.11 and 2.12.
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0"
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"
 )
 
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
   "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
-  "org.mockito" % "mockito-core" % "4.2.0" % Test
+  "org.mockito" % "mockito-core" % "5.8.0" % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.9.7

--- a/src/main/scala/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
+++ b/src/main/scala/com/github/stijndehaes/playprometheusfilters/metrics/Metrics.scala
@@ -152,7 +152,7 @@ object LatencyRequestMetrics {
 
       new LatencyRequestMetric(metric, unmatchedDefaults) {
         override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
-          metric.labels(routeLabel, statusLabel, controllerLabel, pathLabel, verbLabel).observe(requestTime)
+          this.metric.labels(routeLabel, statusLabel, controllerLabel, pathLabel, verbLabel).observe(requestTime)
         }
       }
     }
@@ -169,7 +169,7 @@ object LatencyRequestMetrics {
         .register(registry)
       new LatencyRequestMetric(metric, unmatchedDefaults) {
         override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
-          metric.observe(requestTime)
+          this.metric.observe(requestTime)
         }
       }
     }
@@ -188,7 +188,7 @@ object LatencyRequestMetrics {
 
       new LatencyRequestMetric(metric, unmatchedDefaults) {
         override def mark(requestTime: Double)(implicit requestHeader: RequestHeader, result: Result): Unit = {
-          metric.labels(routeLabel).observe(requestTime)
+          this.metric.labels(routeLabel).observe(requestTime)
         }
       }
     }

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/RouteLatencyFilterSpec.scala
@@ -17,10 +17,11 @@ import play.api.test.Helpers.stubControllerComponents
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import akka.stream.Materializer
 
 class RouteLatencyFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer = app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteCounterFilterSpec.scala
@@ -17,10 +17,11 @@ import play.api.test.Helpers.stubControllerComponents
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import akka.stream.Materializer
 
 class StatusAndRouteCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer= app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyAndCounterFilterSpec.scala
@@ -19,10 +19,11 @@ import play.api.test.Helpers.stubControllerComponents
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import akka.stream.Materializer
 
 class StatusAndRouteLatencyAndCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer= app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusAndRouteLatencyFilterSpec.scala
@@ -18,10 +18,11 @@ import play.api.test.Helpers.stubControllerComponents
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import akka.stream.Materializer
 
 class StatusAndRouteLatencyFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite  {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer= app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {

--- a/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
+++ b/src/test/scala/com/github/stijndehaes/playprometheusfilters/filters/StatusCounterFilterSpec.scala
@@ -14,10 +14,11 @@ import play.api.test.Helpers.stubControllerComponents
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import akka.stream.Materializer
 
 class StatusCounterFilterSpec extends AnyWordSpec with Matchers with MockitoSugar with Results with DefaultAwaitTimeout with FutureAwaits with GuiceOneAppPerSuite {
 
-  private implicit val mat = app.materializer
+  private implicit val mat: Materializer= app.materializer
   private val configuration = mock[Configuration]
 
   "Filter constructor" should {


### PR DESCRIPTION
- Upgraded Sbt, Play and also other Scala dependencies.
- Fixed some minor compiler warnings.
- Removed cross compiling to Scala 2.12.